### PR TITLE
#608 return cms version as a header

### DIFF
--- a/config/middlewares.ts
+++ b/config/middlewares.ts
@@ -2,6 +2,13 @@ export default [
   'strapi::errors',
   'strapi::security',
   'strapi::cors',
+  {
+    name: 'global::version-injector',
+    config: {
+      enabled: true,
+      conf: {},
+    },
+  },
   'strapi::poweredBy',
   'strapi::logger',
   'strapi::query',

--- a/src/middlewares/version-injector.ts
+++ b/src/middlewares/version-injector.ts
@@ -3,6 +3,8 @@
  */
 
 import { Strapi } from '@strapi/strapi';
+import {version} from './../../package.json';
+
 
 export default (config, { strapi }: { strapi: Strapi }) => {
   // Add your own logic here.
@@ -10,7 +12,7 @@ export default (config, { strapi }: { strapi: Strapi }) => {
     // strapi.log.info('In version-injector middleware.');
 
     await next();
-    ctx.set('cms-version', process.env.npm_package_version);
+    ctx.set('cms-version', version);
     ctx.set('Access-Control-Expose-Headers', 'cms-version');
   };
 };

--- a/src/middlewares/version-injector.ts
+++ b/src/middlewares/version-injector.ts
@@ -1,0 +1,15 @@
+/**
+ * `version-injector` middleware
+ */
+
+import { Strapi } from '@strapi/strapi';
+
+export default (config, { strapi }: { strapi: Strapi }) => {
+  // Add your own logic here.
+  return async (ctx, next) => {
+    // strapi.log.info('In version-injector middleware.');
+
+    await next();
+    ctx.set('cms-version', process.env.npm_package_version);
+  };
+};

--- a/src/middlewares/version-injector.ts
+++ b/src/middlewares/version-injector.ts
@@ -11,5 +11,6 @@ export default (config, { strapi }: { strapi: Strapi }) => {
 
     await next();
     ctx.set('cms-version', process.env.npm_package_version);
+    ctx.set('Access-Control-Expose-Headers', 'cms-version');
   };
 };


### PR DESCRIPTION
Code to return cms version mentioned in the package.json file as a custom header in the response