### PR TITLE
feat(amr-page): add amr-page single-type for AMR landing tooltips

### DIFF
--- a/src/api/amr-page/content-types/amr-page/schema.json
+++ b/src/api/amr-page/content-types/amr-page/schema.json
@@ -1,0 +1,46 @@
+{
+  "kind": "singleType",
+  "collectionName": "amr_pages",
+  "info": {
+    "singularName": "amr-page",
+    "pluralName": "amr-pages",
+    "displayName": "AMR Page"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "trendTooltip": {
+      "type": "text",
+      "maxLength": 500,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "substanceTooltip": {
+      "type": "text",
+      "maxLength": 500,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "multiTooltip": {
+      "type": "text",
+      "maxLength": 500,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    }
+  }
+}

--- a/src/api/amr-page/controllers/amr-page.ts
+++ b/src/api/amr-page/controllers/amr-page.ts
@@ -1,0 +1,7 @@
+/**
+ * amr-page controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::amr-page.amr-page');

--- a/src/api/amr-page/routes/amr-page.ts
+++ b/src/api/amr-page/routes/amr-page.ts
@@ -1,0 +1,7 @@
+/**
+ * amr-page router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::amr-page.amr-page');

--- a/src/api/amr-page/services/amr-page.ts
+++ b/src/api/amr-page/services/amr-page.ts
@@ -1,0 +1,7 @@
+/**
+ * amr-page service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::amr-page.amr-page');


### PR DESCRIPTION
Three localized, optional text fields (maxLength 500) keyed to the Trend / Substance / Multi cards on the antimicrobial-resistance page: trendTooltip, substanceTooltip, multiTooltip. Editors populate per locale; an empty field hides the corresponding info icon on the client. Public-role find permission must be enabled in admin once.