### PR TITLE
feat(zncms268): replace antimicrobial collection with amu-page single…

### DIFF
--- a/src/api/amr-page/content-types/amr-page/schema.json
+++ b/src/api/amr-page/content-types/amr-page/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "amr-page",
     "pluralName": "amr-pages",
-    "displayName": "AMR Page"
+    "displayName": "AMR Page Information",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true

--- a/src/api/amu-page/content-types/amu-page/schema.json
+++ b/src/api/amu-page/content-types/amu-page/schema.json
@@ -1,11 +1,10 @@
 {
-  "kind": "collectionType",
-  "collectionName": "antimicrobials",
+  "kind": "singleType",
+  "collectionName": "amu_pages",
   "info": {
-    "singularName": "antimicrobial",
-    "pluralName": "antimicrobials",
-    "displayName": "antimicrobial",
-    "description": ""
+    "singularName": "amu-page",
+    "pluralName": "amu-pages",
+    "displayName": "AMU Page"
   },
   "options": {
     "draftAndPublish": true
@@ -18,7 +17,6 @@
   "attributes": {
     "title": {
       "type": "string",
-      "required": true,
       "pluginOptions": {
         "i18n": {
           "localized": true
@@ -31,8 +29,7 @@
         "i18n": {
           "localized": true
         }
-      },
-      "required": true
+      }
     }
   }
 }

--- a/src/api/amu-page/controllers/amu-page.ts
+++ b/src/api/amu-page/controllers/amu-page.ts
@@ -1,0 +1,7 @@
+/**
+ * amu-page controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::amu-page.amu-page');

--- a/src/api/amu-page/routes/amu-page.ts
+++ b/src/api/amu-page/routes/amu-page.ts
@@ -1,0 +1,7 @@
+/**
+ * amu-page router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::amu-page.amu-page');

--- a/src/api/amu-page/services/amu-page.ts
+++ b/src/api/amu-page/services/amu-page.ts
@@ -1,0 +1,7 @@
+/**
+ * amu-page service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::amu-page.amu-page');

--- a/src/api/antimicrobial/controllers/antimicrobial.ts
+++ b/src/api/antimicrobial/controllers/antimicrobial.ts
@@ -1,7 +1,0 @@
-/**
- * antimicrobial controller
- */
-
-import { factories } from '@strapi/strapi'
-
-export default factories.createCoreController('api::antimicrobial.antimicrobial');

--- a/src/api/antimicrobial/routes/antimicrobial.ts
+++ b/src/api/antimicrobial/routes/antimicrobial.ts
@@ -1,7 +1,0 @@
-/**
- * antimicrobial router
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreRouter('api::antimicrobial.antimicrobial');

--- a/src/api/antimicrobial/services/antimicrobial.ts
+++ b/src/api/antimicrobial/services/antimicrobial.ts
@@ -1,7 +1,0 @@
-/**
- * antimicrobial service
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreService('api::antimicrobial.antimicrobial');

--- a/src/api/information/content-types/information/schema.json
+++ b/src/api/information/content-types/information/schema.json
@@ -4,7 +4,7 @@
   "info": {
     "singularName": "information",
     "pluralName": "informations",
-    "displayName": "MD Information",
+    "displayName": "Filter info Buttons",
     "description": ""
   },
   "options": {

--- a/src/api/resistance-table/content-types/resistance-table/schema.json
+++ b/src/api/resistance-table/content-types/resistance-table/schema.json
@@ -4,7 +4,7 @@
   "info": {
     "singularName": "resistance-table",
     "pluralName": "resistance-tables",
-    "displayName": "Resistance_Table",
+    "displayName": "AMR Cutoff Table",
     "description": ""
   },
   "options": {


### PR DESCRIPTION
… type

- Delete antimicrobial content-type, controller, routes and service
- Add amu-page API (single type)
- Rename display names: AMR Page -> AMR Page Information, MD Information -> Filter info Buttons, Resistance_Table -> AMR Cutoff Table