### PR TITLE
ci(cms): cache yarn deps, run tests, scope QA deploy to environment

### DIFF
--- a/.github/workflows/cd-qa.yml
+++ b/.github/workflows/cd-qa.yml
@@ -17,8 +17,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.19.5'
+          cache: 'yarn'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Build
         run: yarn build
 
@@ -26,6 +27,7 @@ jobs:
     name: 'Deploy to QA'
     runs-on: ubuntu-latest
     needs: build
+    environment: QA
     timeout-minutes: 25
     steps:
       # we need the branch name you just pushed (develop or PR head)
@@ -46,7 +48,7 @@ jobs:
           script: |
             set -x
 
-            APP_DIR="${{ secrets.QA_PATH }}"
+            APP_DIR="${{ vars.APP_PATH }}"
             REPO_URL="https://github.com/SiLeBAT/zoonotify-cms.git"
             BRANCH="${{ steps.extract_branch.outputs.branch }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.19.5'
+          cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
+
+      - name: Test
+        run: yarn test
 
       - name: Build
         run: yarn build


### PR DESCRIPTION
- Add `cache: yarn` to setup-node in CI and CD (caches the yarn download cache keyed on yarn.lock)
- Use `yarn install --frozen-lockfile` for reproducible installs
- Run `yarn test` (vitest) as a CI gate
- Scope the QA deploy job to a `QA` GitHub Environment