### PR TITLE
feat(version-injector): report the deployed commit hash on QA and loc…

### DIFF
--- a/.github/workflows/cd-qa.yml
+++ b/.github/workflows/cd-qa.yml
@@ -98,6 +98,16 @@ jobs:
             git checkout "$BRANCH" || git checkout -B "$BRANCH" "origin/$BRANCH"
             git pull --ff-only || true
 
+            # QA reports the deployed commit instead of the package version:
+            # version-injector picks CMS_COMMIT_HASH up and sends it as the
+            # `cms-commit` response header, which the client footer shows.
+            # Production never sets it, so it keeps reporting the version.
+            echo "==> Record deployed commit"
+            COMMIT_HASH="$(git rev-parse --short HEAD)"
+            touch .env
+            sed -i '/^CMS_COMMIT_HASH=/d' .env
+            echo "CMS_COMMIT_HASH=$COMMIT_HASH" >> .env
+
             bash ./deploy.sh
 
             echo "Deploy finished."

--- a/src/middlewares/version-injector.ts
+++ b/src/middlewares/version-injector.ts
@@ -2,14 +2,49 @@
  * `version-injector` middleware
  */
 
+import { execSync } from 'child_process';
 import type { Strapi as StrapiType } from '@strapi/types/dist/core';
 import { version } from './../../package.json';
+
+/**
+ * Short hash of the running commit. The QA deploy writes CMS_COMMIT_HASH into
+ * .env; local dev reads it from the working copy. Production deliberately gets
+ * neither, so released deployments report the package version.
+ * Returns '' when git is unavailable or this is not a checkout.
+ */
+function resolveCommitHash(): string {
+  if (process.env.CMS_COMMIT_HASH) {
+    return process.env.CMS_COMMIT_HASH;
+  }
+  if (process.env.NODE_ENV === 'production') {
+    return '';
+  }
+  try {
+    return execSync('git rev-parse --short HEAD', {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return '';
+  }
+}
+
+// Resolved once at load; the commit cannot change while the process runs.
+const commitHash = resolveCommitHash();
 
 export default (config: any, { strapi }: { strapi: StrapiType }) => {
   return async (ctx: any, next: () => Promise<any>) => {
     await next();
     ctx.set('cms-version', version);
-    ctx.set('Access-Control-Expose-Headers', 'cms-version');
+    if (commitHash) {
+      ctx.set('cms-commit', commitHash);
+    }
+    ctx.set(
+      'Access-Control-Expose-Headers',
+      commitHash ? 'cms-version, cms-commit' : 'cms-version'
+    );
   };
 };
 


### PR DESCRIPTION
…al dev

The cms-version header carried the package version, which does not identify what is actually running on QA, where every push to develop deploys the same version.

Send an additional cms-commit header holding a short commit hash, resolved from CMS_COMMIT_HASH (written into .env by the QA deploy) or, failing that, from the local working copy. The local lookup is skipped when NODE_ENV is production, so production keeps reporting the version alone. Resolved once at load rather than per request.

A separate header, rather than overloading cms-version, lets the client label the value honestly instead of guessing whether it is a version.