### PR TITLE
fix(version-injector): stamp the commit hash into a file, not .env

### DIFF
--- a/.github/workflows/cd-qa.yml
+++ b/.github/workflows/cd-qa.yml
@@ -99,14 +99,15 @@ jobs:
             git pull --ff-only || true
 
             # QA reports the deployed commit instead of the package version:
-            # version-injector picks CMS_COMMIT_HASH up and sends it as the
+            # version-injector reads .commit-hash and sends it as the
             # `cms-commit` response header, which the client footer shows.
-            # Production never sets it, so it keeps reporting the version.
+            # Production never writes the file, so it keeps reporting the
+            # version. Deliberately NOT an .env entry -- appending to .env
+            # glues onto the last credential line when that file has no
+            # trailing newline, which fails silently.
             echo "==> Record deployed commit"
-            COMMIT_HASH="$(git rev-parse --short HEAD)"
-            touch .env
-            sed -i '/^CMS_COMMIT_HASH=/d' .env
-            echo "CMS_COMMIT_HASH=$COMMIT_HASH" >> .env
+            git rev-parse --short HEAD > .commit-hash
+            echo "Stamped .commit-hash: $(cat .commit-hash)"
 
             bash ./deploy.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ coverage
 ############################
 
 .env
+.commit-hash
 license.txt
 exports
 *.cache

--- a/src/middlewares/version-injector.ts
+++ b/src/middlewares/version-injector.ts
@@ -3,18 +3,34 @@
  */
 
 import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import type { Strapi as StrapiType } from '@strapi/types/dist/core';
 import { version } from './../../package.json';
 
+// Written by the QA deploy, next to the .env in the app root. A dedicated file
+// rather than an .env entry: appending to .env risks gluing onto a credential
+// line that has no trailing newline, which fails silently.
+const STAMP_FILE = '.commit-hash';
+
 /**
- * Short hash of the running commit. The QA deploy writes CMS_COMMIT_HASH into
- * .env; local dev reads it from the working copy. Production deliberately gets
- * neither, so released deployments report the package version.
- * Returns '' when git is unavailable or this is not a checkout.
+ * Short hash of the running commit. The QA deploy stamps it into .commit-hash;
+ * local dev reads it from the working copy. Production gets neither, so
+ * released deployments report the package version.
+ * Returns '' when the hash cannot be determined.
  */
 function resolveCommitHash(): string {
+  // Escape hatch for manual runs; not used by any deploy.
   if (process.env.CMS_COMMIT_HASH) {
-    return process.env.CMS_COMMIT_HASH;
+    return process.env.CMS_COMMIT_HASH.trim();
+  }
+  try {
+    const stamped = readFileSync(join(process.cwd(), STAMP_FILE), 'utf8').trim();
+    if (stamped) {
+      return stamped;
+    }
+  } catch {
+    // Not a stamped deployment; fall through.
   }
   if (process.env.NODE_ENV === 'production') {
     return '';


### PR DESCRIPTION
The QA deploy appended CMS_COMMIT_HASH to .env after copying env.qa over it. env.qa has no trailing newline, so the append glued onto the last credential line: CMS_COMMIT_HASH never became a variable, and the preceding variable silently took a corrupted value. QA kept reporting cms-version with no cms-commit header.

Write the hash to a dedicated .commit-hash file in the app root and read that instead. Nothing parses or rewrites the credentials file, so the failure mode is gone rather than papered over, and the deploy log now echoes what it stamped.

CMS_COMMIT_HASH still works as a manual override. Production writes no stamp file and keeps reporting the package version.